### PR TITLE
Less redundant HOWTO names

### DIFF
--- a/200_create/300_howto/100_general.md
+++ b/200_create/300_howto/100_general.md
@@ -1,4 +1,4 @@
-# General howtos
+# General
 
 In this section we explain howtos that are not specific to any template or
 target but to all of them. You'll see that most of them are related to firstboot

--- a/200_create/300_howto/110_kde.md
+++ b/200_create/300_howto/110_kde.md
@@ -1,4 +1,4 @@
-# KDE howtos
+# KDE
 
 These howtos are related to KDE. Since there are two KDE versions, some of them
 are specific to one version and some of them can be applied to both. Most of
@@ -28,18 +28,18 @@ On some cases you may want to launch konqueror with a specific profile. In order
 3. Load the new profile ("Settings" -» "Load View Profile" -» your_profile).
 4. Change the window size, the menus that are visible, etc.
 5. Save your profile ("Settings" -» "Save View Profile your_profile ...").
-6. Include these files into your appliance (on the overlay section):  
-    
+6. Include these files into your appliance (on the overlay section):
+
        1. /home/tux/.kde/share/apps/konqueror/profiles/your_profile
-       2. /home/tux/.kde/share/config/konquerorrc  
+       2. /home/tux/.kde/share/config/konquerorrc
 
 Launch Konqueror with "konqueror --profile your_profile" on your scripts.
 
 
 ## How to launch an application in fullscreen mode in KDE(3)
 
-You can use that together with the "How to launch a kde application on login " so you have kind of a kiosk.  
-       
+You can use that together with the "How to launch a kde application on login " so you have kind of a kiosk.
+
        kstart --fullscreen [--ontop] application application_parameters
 
 
@@ -64,7 +64,7 @@ If you want to customize the SUSEgreeter, like the text on it, the icons, etc. e
 
 ## How to start an empty kde session at every login
 
-* On test drive, open a console and type  
+* On test drive, open a console and type
 
        kcmshell kcmsmserver
 

--- a/200_create/300_howto/120_gnome.md
+++ b/200_create/300_howto/120_gnome.md
@@ -1,4 +1,4 @@
-# GNOME howtos
+# GNOME
 
 These are howtos related to the gnome template. Some of them are the same as KDE
 and some are different.

--- a/200_create/300_howto/130_vmware.md
+++ b/200_create/300_howto/130_vmware.md
@@ -1,10 +1,10 @@
-# VMware Howtos
+# VMware
 
 Virtual machines in the VMware format are similar to disk images, but with
 special information which specifies memory and hard drive sizes. They do not
 include a swap partition as it is common practice to leave memory management to
 the hypervisor. The swap setting in SUSE Studio only applies to disk images.
-To use these images, simply open the file in VMware, VMware player, or VirtualBox.  
+To use these images, simply open the file in VMware, VMware player, or VirtualBox.
 This set of howtos are specific to VMware machines. They are focused on changing
 some stuff after the image is built but usually after booting for the first
 time.

--- a/200_create/300_howto/140_virtualbox.md
+++ b/200_create/300_howto/140_virtualbox.md
@@ -1,4 +1,4 @@
-# VirtualBox Howtos
+# VirtualBox
 
 VirtualBox can run vmdk discs so the vmware build can work for VirtualBox as
 well. However, the vmware tools will not, so you may want to add the virtualbox
@@ -20,8 +20,8 @@ Check [VirtualBox (Linux, Windows, Mac OS X, Solaris)][oo-virtualbox] for more d
 * Add the package `virtualbox-ose-guest-tools`.
 * Alternatively, if the previous option does not work, you can try the following if you are using the PUEL VirtualBox (PUEL = Personal Use and Evaluation License ). When running the appliance with VirtualBox, go to Devices->Install Guest Additions. This will mount a virtual CD from the image VBoxGuestAdditions.iso. Copy the file VBoxLinuxAdditions-x86.run into a local folder. Write a script that will execute that file (as root) the first time the machine boots (and after all the services have been loaded)--if you are only interested in being able to share folders, you can run VBoxLinuxAdditions-x86.run vfs-module instead. Keep in mind that you will have to reboot the machine at the end of the installation. Upload the script and the VBoxLinuxAdditions-x86.run file to your appliance in SUSE Studio using the Overlay files section. Before building your appliance, make sure to include the following packages: kernel-source, linux-kernel-headers, make, gcc, and gcc-c++.
 * To set up a folder to share, run the following command as root:
-  
-       mount -t vboxsf name -o uid=1000 mountpoint 
+
+       mount -t vboxsf name -o uid=1000 mountpoint
 
 * where 1000 is the user id of tux (see `/etc/passwd`), and name is the name given to the shared folders when you set them up in the VirtualBox shared folder settings dialog.
 

--- a/200_create/300_howto/150_xen.md
+++ b/200_create/300_howto/150_xen.md
@@ -1,4 +1,4 @@
-# Xen Howtos
+# Xen
 
 These howtos are related to Xen DomU appliances built with SUSE Studio. Some if
 not all of these changes can be made automatic by scripting them.
@@ -87,7 +87,7 @@ Basically you only need to adapt the 'disk' entry in order for xen to actually f
 * You need to edit this option in order to be able to start the guest.
 
 As xen does not understand relative paths in its config file, you need to adapt the location in your configuration according to the location of the disk image. If you e.g unpacked the guest tar.gz file in /opt/guests so you now have the disk image located in /opt/guests/Appliance_name-Version/ you nedd to change the disk entry in the config from
-    
+
     disk=[ "tap:aio:Appliance_name.architecture-versionraw,xvda,w" ]
 
 to
@@ -100,7 +100,7 @@ in order to be able to boot the guest.
 **network**
 
 The last item in the config determines on how the guest will access to hosts network using the keyword vif
-There are several different options possible and explaining them would exceed the scope of this document. In general the default set value should work with correctly configured Xen Dom0s that use the default name for the bridge guests can connect to. The guest will start without this item being changed but it could happen that it misses network connectivity due to a different bridge name in the Dom0 or even a different method of making networking available to guests. 
+There are several different options possible and explaining them would exceed the scope of this document. In general the default set value should work with correctly configured Xen Dom0s that use the default name for the bridge guests can connect to. The guest will start without this item being changed but it could happen that it misses network connectivity due to a different bridge name in the Dom0 or even a different method of making networking available to guests.
 
 Please read [How to configure networking for a Xen guest][xen-config] for more details on Xen bridged networking.
 
@@ -119,7 +119,7 @@ this will configure you a bridge 'xenbr0' and connect the ethernet interface of 
 ### Doing it manually
 
 * disable any specific configuration for your ethernet interface by removing its config file in /etc/sysconfig/network
-* create config file `/etc/sysconfig/network/ifcfg-xenbr0` for the bridge xenbr0 with the following content:  
+* create config file `/etc/sysconfig/network/ifcfg-xenbr0` for the bridge xenbr0 with the following content:
 
 
         BOOTPROTO='dhcp'
@@ -137,7 +137,7 @@ this will configure you a bridge 'xenbr0' and connect the ethernet interface of 
         STARTMODE='onboot'
         USERCONTROL='no'
 
-* restart your network b y running  
+* restart your network b y running
 `/etc/init.d/network restart`
 
 Run `ip addr`. If everything works as expected, you should now see an interface xenbr0 which gets the host's IP address assigned and eth0 not having an IP address anymore. Ping some host to make sure everything works,
@@ -163,7 +163,7 @@ Run `ip addr`. If everything works as expected, you should now see an interface 
 **X forwarding with ssh**
 
 * in order to use X forwarding with ssh you need the option -X like this:
-       
+
        ssh -X <username>@<hostname|ip adress of DomU>
 
 * once logged in you should be able to launch any X based application and get its graphical output forwarded to the machine your ssh client is running on.
@@ -212,15 +212,15 @@ This setup has been successful tested with xdm and kdm.
 ### start a vncserver and access it from remote with a vncviewer
 
 * With latest images built in SUSE Studio this is already configured for xen guests, for older images you need to add the following line to the xenconfig file used to add/create a guest:
-   
+
        vfb = ["type=vnc,vncunused=1,vnclisten=0.0.0.0"]
 
 * to access the guest you can either run (0 is the port used for the first guest being started, others then simply increase the port by one)
-   
+
        vncviewer :0
-  
-  or 
-  
+
+  or
+
        virt-viewer <guest name>|<guest ID>
 
   This will then open a vnc view to the framebufer of the guest

--- a/200_create/300_howto/170_livecd.md
+++ b/200_create/300_howto/170_livecd.md
@@ -1,6 +1,6 @@
-# LiveCD/DVD (.iso) Howtos
+# LiveCD/DVD (.iso)
 
-SUSE Studio supports the creation of custom bootable CDs and DVDs. Optionally, these discs can support installation from the live media to the hard drive as well.  
+SUSE Studio supports the creation of custom bootable CDs and DVDs. Optionally, these discs can support installation from the live media to the hard drive as well.
 Most operating systems make disc burning easy. Once you have downloaded the file completely, simply right-click on the file and select something like "burn ISO file to disc".
 
 


### PR DESCRIPTION
Since the howtos are already in a /howto/ path, the /howto/[Subject]_howtos title is redundant.
