### PR TITLE
Fix code block indent issues using haml's whitespace preservation.

### DIFF
--- a/_view/template.haml
+++ b/_view/template.haml
@@ -16,7 +16,7 @@
         =render_toc
 
       #wrapper.content
-        = render_content
+        ~ render_content
 
   #footer
     %ul.links


### PR DESCRIPTION
_markdown_ gets processed, then injected into a _haml_ template.  The _markdown_ content was being injected with _haml_'s regular whitespace rules, wreaking havoc on '<pre><code' blocks.
# thereifixedit
