### PR TITLE
Kernel#system calls avoid shell

### DIFF
--- a/do_create
+++ b/do_create
@@ -1,7 +1,5 @@
 #!/usr/bin/ruby
 
-require "shellwords"
-
 if ARGV.size != 1
   STDERR.puts "Usage: do_create <output_directory>"
   exit 1
@@ -13,13 +11,13 @@ puts "Generating help into directory '#{output_dir}'"
 
 input_dir = File.expand_path( File.dirname( __FILE__ ) )
 
-cmd = "helphelp -o #{Shellwords.escape(output_dir)} #{Shellwords.escape(input_dir)}"
+cmd = ['helphelp', '-o', output_dir, input_dir]
 
-if !system cmd
+if !system *cmd
   STDERR.puts "Error executing command '#{cmd}'"
   STDERR.puts "Make sure you have installed the helphelp gem by running"
   STDERR.puts "  sudo gem install helphelp"
   exit 1
 end
 
-system "xdg-open #{output_dir}/overview.html"
+system "xdg-open", "#{output_dir}/overview.html"


### PR DESCRIPTION
Kernel#system calls are done with a list of arguments instead
of a single string.  this way the code ends up using fork/exec
instead.
