### PR TITLE
Document bnc#798987

### DIFF
--- a/200_create/300_howto/150_xen.md
+++ b/200_create/300_howto/150_xen.md
@@ -296,6 +296,10 @@ This setup has been successful tested with xdm and kdm.
 
   This will then open a vnc view to the framebufer of the guest
 
+* If virt-viewer is supposed to be run from a Studio built Dom0 with
+  X forwarding, the packages virt-viewer and xorg-x11-fonts-scalable
+  need to be added to the appliance before.
+
 
 ### make a second graphic card available to DomU via pci
 


### PR DESCRIPTION
Document that when using virt-viewer on Dom0 to install the required
packages before. This issue might be only relevant for SLES 10 SP4 since
our SLES 11 SP2 XEN Host Mode appliance doesn't seem to be shipped with
virt-viewer by default but if people want it there they also have to
install it so I think it is fine that way.
