### PR TITLE
PUT /api/v2/user/appliances/<id>/configuration result corrected

### DIFF
--- a/800_api/920_v2/200_appliances.md
+++ b/800_api/920_v2/200_appliances.md
@@ -59,9 +59,7 @@ PUT /api/v2/user/appliances/`<id>`/configuration
 >       </network>
 >     </configuration>
 
-> The result is then the current configuration setting, or an error.
->
-> Result: [Example](configuration.xml)
+> The result is then a success message (`<success></success>`) or an error.
 
 GET /api/v2/user/appliances/`<id>`/configuration/logo
 > * `<id>`: Id of the appliance.


### PR DESCRIPTION
I noticed this while working at susestudio-lib-java - I assume that it is just a documentation error. If the method really should return a `<configuration>` element I will open a Studio bug.
