### PR TITLE
Add missing elements: estimated_[raw|compressed]_size

### DIFF
--- a/800_api/920_v2/appliance.xml
+++ b/800_api/920_v2/appliance.xml
@@ -2,6 +2,8 @@
   <id>24</id>
   <name>Cornelius' JeOS</name>
   <last_edited>2009-04-24 12:09:42 UTC</last_edited>
+  <estimated_raw_size>560 MB</estimated_raw_size>
+  <estimated_compressed_size>160 MB</estimated_compressed_size>
   <edit_url>http://susestudio.com/appliance/edit/24</edit_url>
   <icon_url>http://susestudio.com/api/v1/user/appliance_icon/1234</icon_url>
   <basesystem>11.1</basesystem>

--- a/800_api/920_v2/appliances.xml
+++ b/800_api/920_v2/appliances.xml
@@ -3,6 +3,8 @@
     <id>24</id>
     <name>Cornelius' JeOS</name>
     <last_edited>2009-04-24 12:09:42 UTC</last_edited>
+    <estimated_raw_size>540 MB</estimated_raw_size>
+    <estimated_compressed_size>160 MB</estimated_compressed_size>
     <edit_url>http://susestudio.com/appliance/edit/24</edit_url>
     <icon_url>http://susestudio.com/api/v1/user/appliance_icon/1234</icon_url>
     <basesystem>11.1</basesystem>
@@ -25,6 +27,8 @@
     <id>8</id>
     <name>Text Only</name>
     <last_edited>2009-04-20 14:21:49 UTC</last_edited>
+    <estimated_raw_size>490 MB</estimated_raw_size>
+    <estimated_compressed_size>160 MB</estimated_compressed_size>
     <edit_url>http://susestudio.com/appliance/edit/8</edit_url>
     <icon_url>http://susestudio.com/api/v1/user/appliance_icon/1234</icon_url>
     <parent>


### PR DESCRIPTION
We found the "estimated_[raw|compressed]_size" elements to be missing in appliance.xml as well as appliances.xml. They seem to be returned from real servers in any case, as far as I can see.

By the way: Can we expect that the returned value is always a string with the "MB" suffix? We were trying to parse it into a number, see this [commit](https://github.com/susestudio/susestudio-lib-java/commit/926f051f28f82cfe5d64cc8e1786f0d679719828).
