### PR TITLE
fix link to libarchive windows installer

### DIFF
--- a/200_create/300_howto/100_general.md
+++ b/200_create/300_howto/100_general.md
@@ -55,8 +55,7 @@ Here is a step-by-step guide for
 `LAMP_Server.i686-1.0.0.vmx.tar.gz`:
 
 1. Download and install LibArchive:
-   [http://downloads.sourceforge.net/gnuwin32/libarchive-2.4.12-1-setup.exe]
-[libarchive2].
+   [http://downloads.sourceforge.net/gnuwin32/libarchive-2.4.12-1-setup.exe][libarchive2].
 2. Add the LibArchive path (default is `C:\Program Files\GnuWin32\bin`)
    to your [system %PATH% variable][win-sys-path].
 3. Extract the tarball by executing the following in the command


### PR DESCRIPTION
---

| Maruku tells you:
+---------------------------------------------------------------------------
| Could not find ref_id = "httpdownloadssourceforgenetgnuwin32libarchive24121setupexe" for md_link([
|   "http://downloads.sourceforge.net/gnuwin32/libarchive-2.4.12-1-setup.exe"
| ],"httpdownloadssourceforgenetgnuwin32libarchive24121setupexe")
| Available refs are ["wikigzip", "wikitar", "wikiark", "wikifileroller", "winrar", "7zip", "libarchive", "libarchive2", "libarchivetool", "winsyspath"]
+---------------------------------------------------------------------------
!/usr/lib/ruby/gems/1.9.1/gems/maruku-0.6.1/lib/maruku/errors_management.rb:49:in `maruku_error'
!/usr/lib/ruby/gems/1.9.1/gems/maruku-0.6.1/lib/maruku/output/to_html.rb:716:in`to_html_link'
!/usr/lib/ruby/gems/1.9.1/gems/maruku-0.6.1/lib/maruku/output/to_html.rb:970:in `block in array_to_html'
!/usr/lib/ruby/gems/1.9.1/gems/maruku-0.6.1/lib/maruku/output/to_html.rb:961:in`each'
!/usr/lib/ruby/gems/1.9.1/gems/maruku-0.6.1/lib/maruku/output/to_html.rb:961:in `array_to_html'
___________________________________________________________________________
Not creating a link for ref_id = "httpdownloadssourceforgenetgnuwin32libarchive24121setupexe".
