### PR TITLE
fix link vs code display confusion

### DIFF
--- a/200_create/300_howto/150_xen.md
+++ b/200_create/300_howto/150_xen.md
@@ -74,6 +74,7 @@ You can work around the issue by replacing "tap:aio" by "file" in the
 SLES 10 guest .xenconfig file.
 
 For example:
+
     disk=[ "file:Appliance_name.architecture-version,xvda,w" ]
 
 ---


### PR DESCRIPTION
| Maruku tells you:
+---------------------------------------------------------------------------
| Could not find ref_id = "md_entityldquo_fileappliance_namearchitectureversionxvdaw_md_entityrdquo" for md_link([
|   md_entity("ldquo"),
|   "file:Appliance_name.architecture-version,xvda,w",
|   md_entity("rdquo")
| ],"md_entityldquo_fileappliance_namearchitectureversionxvdaw_md_entityrdquo")
| Available refs are ["xvareadme", "xenconfig", "oosshx", "ooxdmconfig", "oovncserver", "oo2ndgcard"]
+---------------------------------------------------------------------------
!/usr/lib/ruby/gems/1.9.1/gems/maruku-0.6.1/lib/maruku/errors_management.rb:49:in `maruku_error'
!/usr/lib/ruby/gems/1.9.1/gems/maruku-0.6.1/lib/maruku/output/to_html.rb:716:in`to_html_link'
!/usr/lib/ruby/gems/1.9.1/gems/maruku-0.6.1/lib/maruku/output/to_html.rb:970:in `block in array_to_html'
!/usr/lib/ruby/gems/1.9.1/gems/maruku-0.6.1/lib/maruku/output/to_html.rb:961:in`each'
!/usr/lib/ruby/gems/1.9.1/gems/maruku-0.6.1/lib/maruku/output/to_html.rb:961:in `array_to_html'
___________________________________________________________________________
