### PR TITLE
fix two links to FAQ / Troubleshooting

### DIFF
--- a/100_quickstart/106_more-information.md
+++ b/100_quickstart/106_more-information.md
@@ -24,5 +24,5 @@ improve it!
 
 [API]:               ../api/index.html
 [FAQ]:               ../faq.html
-[Troubleshooting]:   ../troubleshoot.html
+[Troubleshooting]:   ../faq/troubleshoot.html
 [how to contribute]: ../contribute.html

--- a/600_faq/000_index.md
+++ b/600_faq/000_index.md
@@ -5,5 +5,5 @@ Here you can find answers to frequently asked questions about SUSE Studio.
 * [General](general.html)
 * [Access](access.html)
 * [Appliances](appliances.html)
-* [Troubleshooting](troubleshooting.html)
+* [Troubleshooting](troubleshoot.html)
 * [Browser Support Policy](browser_policy.html)


### PR DESCRIPTION
we should make sure our technical writers and reviewers
build the html if they make changes.  broken links in the
manual are worse than somewhat broken english.
