### PR TITLE
fix navigation table item for SUSE Cloud

### DIFF
--- a/400_use/625_suse_cloud.md
+++ b/400_use/625_suse_cloud.md
@@ -1,4 +1,4 @@
-## SUSE Cloud
+# SUSE Cloud
 
 [SUSE Cloud][suse_cloud] is a pre-packaged and supported version of OpenStack that has
 been tested to work with the SUSE family of products. It is designed for


### PR DESCRIPTION
page titles must be marked up with a single '#',
the toc table generator breaks otherwise.
