### PR TITLE
Fix link to user page from API help page

### DIFF
--- a/800_api/000_index.md
+++ b/800_api/000_index.md
@@ -19,4 +19,4 @@ within SUSE Studio][studio-api-key].
 
 
 [studio-api]: v2/index.html
-[studio-api-key]: user/account#/api-hooks
+[studio-api-key]: /user/account#/api-hooks


### PR DESCRIPTION
The link to the user page on main API help page [1] has wrong URL [2] and should point to correct user page URL [3].

[1] http://susestudio.com/help/api/index.html
[2] http://susestudio.com/help/api/user/account#/api-hooks
[3] http://susestudio.com/user/account#/api-hooks
